### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=PEK
 maintainer=PEK <kevinperillo98@gmail.com
 sentence=Arduino library for RTC
 paragraph=Arduino library for RTC
-category=Real Time Clock
+category=Timing
 url=https://github.com/MootSeeker/DS3231
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Real Time Clock' in library RTC Lib  is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format